### PR TITLE
[Device][Backend] refactor: extract binding methods and DeviceGuard

### DIFF
--- a/backend/core/PrivateUse1Guard.h
+++ b/backend/core/PrivateUse1Guard.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <c10/core/DeviceType.h>
+#include <c10/core/impl/InlineDeviceGuard.h>
+#include <c10/core/impl/InlineStreamGuard.h>
+
+#include "backend/core/impl/PrivateUse1GuardImpl.h"
+
+namespace c10_backend {
+
+// This code is kind of boilerplatey.  See Note [Whither the DeviceGuard
+// boilerplate]
+
+/// A variant of DeviceGuard that is specialized for PrivateUse1.  It accepts
+/// integer indices (interpreting them as PrivateUse1 devices) and is a little
+/// more efficient than DeviceGuard (it compiles to straight line
+/// cudaSetDevice/cudaGetDevice calls); however, it can only be used
+/// from code that links against PrivateUse1 directly.
+template <typename T>
+struct PrivateUse1Guard {
+  /// No default constructor; see Note [Omitted default constructor from RAII]
+  explicit PrivateUse1Guard() = delete;
+
+  /// Set the current PrivateUse1 device to the passed device index.
+  explicit PrivateUse1Guard(c10::DeviceIndex device_index)
+      : guard_(device_index) {}
+
+  /// Sets the current PrivateUse1 device to the passed device.  Errors if the
+  /// passed device is not a PrivateUse1 device.
+  explicit PrivateUse1Guard(c10::Device device) : guard_(device) {}
+
+  // Copy is not allowed
+  PrivateUse1Guard(const PrivateUse1Guard&) = delete;
+
+  PrivateUse1Guard& operator=(const PrivateUse1Guard&) = delete;
+
+  // Move is not allowed (there is no uninitialized state)
+  PrivateUse1Guard(PrivateUse1Guard&& other) = delete;
+
+  PrivateUse1Guard& operator=(PrivateUse1Guard&& other) = delete;
+  /// Sets the PrivateUse1 device to the given device.  Errors if the given
+  /// device is not a PrivateUse1 device.
+  void set_device(c10::Device device) {
+    guard_.set_device(device);
+  }
+
+  /// Sets the PrivateUse1 device to the given device.  Errors if the given
+  /// device is not a PrivateUse1 device.  (This method is provided for
+  /// uniformity with DeviceGuard).
+  void reset_device(c10::Device device) {
+    guard_.reset_device(device);
+  }
+
+  /// Sets the PrivateUse1 device to the given device index.
+  void set_index(c10::DeviceIndex device_index) {
+    guard_.set_index(device_index);
+  }
+
+  /// Returns the device that was set upon construction of the guard
+  c10::Device original_device() const {
+    return guard_.original_device();
+  }
+
+  /// Returns the last device that was set via `set_device`, if any, otherwise
+  /// the device passed during construction.
+  c10::Device current_device() const {
+    return guard_.current_device();
+  }
+
+ private:
+  /// The guard for the current device.
+  c10::impl::InlineDeviceGuard<T> guard_;
+};
+
+/// A variant of OptionalDeviceGuard that is specialized for PrivateUse1.  See
+/// PrivateUse1Guard for when you can use this.
+template <typename T>
+struct OptionalPrivateUse1Guard {
+  /// Create an uninitialized OptionalPrivateUse1Guard.
+  explicit OptionalPrivateUse1Guard() : guard_() {}
+
+  /// Set the current PrivateUse1 device to the passed Device, if it is not
+  /// nullopt.
+  explicit OptionalPrivateUse1Guard(std::optional<c10::Device> device_opt)
+      : guard_(device_opt) {}
+
+  /// Set the current PrivateUse1 device to the passed device index, if it is
+  /// not nullopt
+  explicit OptionalPrivateUse1Guard(
+      std::optional<c10::DeviceIndex> device_index_opt)
+      : guard_(device_index_opt) {}
+
+  // Copy is not allowed
+  OptionalPrivateUse1Guard(const OptionalPrivateUse1Guard&) = delete;
+
+  OptionalPrivateUse1Guard& operator=(const OptionalPrivateUse1Guard&) = delete;
+
+  // See Note [Move construction for RAII guards is tricky]
+  OptionalPrivateUse1Guard(OptionalPrivateUse1Guard&& other) = delete;
+
+  // See Note [Move assignment for RAII guards is tricky]
+  OptionalPrivateUse1Guard& operator=(OptionalPrivateUse1Guard&& other) =
+      delete;
+
+  /// Sets the PrivateUse1 device to the given device, initializing the guard if
+  /// it is not already initialized.  Errors if the given device is not a
+  /// PrivateUse1 device.
+  void set_device(c10::Device device) {
+    guard_.set_device(device);
+  }
+
+  /// Sets the PrivateUse1 device to the given device, initializing the guard if
+  /// it is not already initialized.  Errors if the given device is not a
+  /// PrivateUse1 device. (This method is provided for uniformity with
+  /// OptionalDeviceGuard).
+  void reset_device(c10::Device device) {
+    guard_.reset_device(device);
+  }
+
+  /// Sets the PrivateUse1 device to the given device index, initializing the
+  /// guard if it is not already initialized.
+  void set_index(c10::DeviceIndex device_index) {
+    guard_.set_index(device_index);
+  }
+
+  /// Returns the device that was set immediately prior to initialization of the
+  /// guard, or nullopt if the guard is uninitialized.
+  std::optional<c10::Device> original_device() const {
+    return guard_.original_device();
+  }
+
+  /// Returns the most recent device that was set using this device guard,
+  /// either from construction, or via set_device, if the guard is initialized,
+  /// or nullopt if the guard is uninitialized.
+  std::optional<c10::Device> current_device() const {
+    return guard_.current_device();
+  }
+
+  /// Restore the original PrivateUse1 device, resetting this guard to
+  /// uninitialized state.
+  void reset() {
+    guard_.reset();
+  }
+
+ private:
+  c10::impl::InlineOptionalDeviceGuard<T> guard_;
+};
+
+} // namespace c10_backend

--- a/backend/core/impl/PrivateUse1GuardImpl.h
+++ b/backend/core/impl/PrivateUse1GuardImpl.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <c10/core/DeviceType.h>
+#include <c10/core/impl/InlineDeviceGuard.h>
+#include <c10/macros/Macros.h>
+
+namespace c10_backend::impl {
+
+/**
+ * All classes which inherit from PrivateUse1GuardImpl should be declared
+ * 'final'.
+ */
+struct PrivateUse1GuardImpl : public c10::impl::DeviceGuardImplInterface {
+  static constexpr c10::DeviceType static_type = c10::DeviceType::PrivateUse1;
+
+  PrivateUse1GuardImpl() = default;
+
+  explicit PrivateUse1GuardImpl(c10::DeviceType t) {
+    TORCH_INTERNAL_ASSERT(t == c10::DeviceType::PrivateUse1);
+  }
+
+  c10::DeviceType type() const final {
+    return c10::DeviceType::PrivateUse1;
+  }
+};
+
+} // namespace c10_backend::impl

--- a/backend/npu/NPUFunctions.cpp
+++ b/backend/npu/NPUFunctions.cpp
@@ -184,4 +184,32 @@ int GetLocalDevice() {
   return local_device;
 }
 
+int32_t getDeviceUtilizationRate(int32_t device) {
+  aclrtUtilizationInfo util_info;
+  util_info.cubeUtilization = 0;
+  util_info.vectorUtilization = 0;
+  util_info.utilizationExtend = nullptr;
+  NPU_CHECK_ERROR(
+      c10_npu::acl::AclrtGetDeviceUtilizationRate(device, &util_info));
+  int32_t cube = util_info.cubeUtilization;
+  int32_t vector = util_info.vectorUtilization;
+  int32_t util_rate = 0;
+
+  // If either vector or cube supports, return its utilization rate.
+  // If both support, return the average rate: (vector + cube) / 2.
+  if (cube == DEVICE_UTILIZATION_NOT_SUPPORT &&
+      vector != DEVICE_UTILIZATION_NOT_SUPPORT) {
+    util_rate = vector;
+  } else if (
+      cube != DEVICE_UTILIZATION_NOT_SUPPORT &&
+      vector == DEVICE_UTILIZATION_NOT_SUPPORT) {
+    util_rate = cube;
+  } else if (
+      cube != DEVICE_UTILIZATION_NOT_SUPPORT &&
+      vector != DEVICE_UTILIZATION_NOT_SUPPORT) {
+    util_rate = (cube + vector) / 2;
+  }
+  return util_rate;
+}
+
 } // namespace c10_npu

--- a/backend/npu/NPUFunctions.cpp
+++ b/backend/npu/NPUFunctions.cpp
@@ -184,7 +184,7 @@ int GetLocalDevice() {
   return local_device;
 }
 
-int32_t getDeviceUtilizationRate(int32_t device) {
+int32_t GetDeviceUtilizationRate(int32_t device) {
   aclrtUtilizationInfo util_info;
   util_info.cubeUtilization = 0;
   util_info.vectorUtilization = 0;

--- a/backend/npu/NPUFunctions.h
+++ b/backend/npu/NPUFunctions.h
@@ -70,7 +70,7 @@ C10_NPU_API int ExchangeDevice(int device);
 
 C10_NPU_API int GetLocalDevice();
 
-C10_NPU_API int32_t getDeviceUtilizationRate(int32_t device);
+C10_NPU_API int32_t GetDeviceUtilizationRate(int32_t device);
 
 enum class SyncDebugMode { L_DISABLED = 0, L_WARN, L_ERROR };
 

--- a/backend/npu/NPUFunctions.h
+++ b/backend/npu/NPUFunctions.h
@@ -68,7 +68,9 @@ C10_NPU_API void device_synchronize();
 
 C10_NPU_API int ExchangeDevice(int device);
 
-int GetLocalDevice();
+C10_NPU_API int GetLocalDevice();
+
+C10_NPU_API int32_t getDeviceUtilizationRate(int32_t device);
 
 enum class SyncDebugMode { L_DISABLED = 0, L_WARN, L_ERROR };
 

--- a/backend/npu/NPUGuardImpl.h
+++ b/backend/npu/NPUGuardImpl.h
@@ -16,7 +16,7 @@
 
 namespace c10_npu {
 namespace impl {
-
+// todo
 struct NPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   static constexpr c10::DeviceType static_type = c10::DeviceType::PrivateUse1;
 

--- a/backend/npu/NPUGuardImpl.h
+++ b/backend/npu/NPUGuardImpl.h
@@ -8,6 +8,7 @@
 #include <backend/npu/impl/acl/include/acl/acl_base.h>
 #include <backend/npu/impl/acl/include/acl/acl_rt.h>
 #include "aten/NPUNativeFunctions.h"
+#include "backend/core/impl/PrivateUse1GuardImpl.h"
 #include "backend/npu/impl/core/NPUException.h"
 #include "backend/npu/NPUFunctions.h"
 #include "backend/npu/NPUStream.h"
@@ -16,20 +17,15 @@
 
 namespace c10_npu {
 namespace impl {
+struct NPUGuardImpl final : public c10_backend::impl::PrivateUse1GuardImpl {
+  NPUGuardImpl() = default;
 
-struct NPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
-  static constexpr c10::DeviceType static_type = c10::DeviceType::PrivateUse1;
-
-  NPUGuardImpl() {}
   explicit NPUGuardImpl(c10::DeviceType t) {
     TORCH_INTERNAL_ASSERT(
         t == c10::DeviceType::PrivateUse1,
         "DeviceType must be NPU. Actual DeviceType is: ",
         t,
         PTA_ERROR(ErrCode::PARAM));
-  }
-  c10::DeviceType type() const override {
-    return c10::DeviceType::PrivateUse1;
   }
   c10::Device exchangeDevice(c10::Device d) const override {
     TORCH_INTERNAL_ASSERT(

--- a/backend/npu/NPUGuardImpl.h
+++ b/backend/npu/NPUGuardImpl.h
@@ -23,7 +23,7 @@ struct NPUGuardImpl final : public c10_backend::impl::PrivateUse1GuardImpl {
   explicit NPUGuardImpl(c10::DeviceType t) {
     TORCH_INTERNAL_ASSERT(
         t == c10::DeviceType::PrivateUse1,
-        "DeviceType must be NPU. Actual DeviceType is: ",
+        "DeviceType must be 'c10::DeviceType::PrivateUse1'. Actual DeviceType is: ",
         t,
         PTA_ERROR(ErrCode::PARAM));
   }

--- a/backend/npu/NPUGuardImpl.h
+++ b/backend/npu/NPUGuardImpl.h
@@ -16,7 +16,7 @@
 
 namespace c10_npu {
 namespace impl {
-// todo
+
 struct NPUGuardImpl final : public c10::impl::DeviceGuardImplInterface {
   static constexpr c10::DeviceType static_type = c10::DeviceType::PrivateUse1;
 

--- a/backend/npu/THNPUCachingHostAllocator.cpp
+++ b/backend/npu/THNPUCachingHostAllocator.cpp
@@ -353,9 +353,7 @@ at::Allocator* getTHNPUCachingHostAllocator() {
 
 c10::Allocator* getPinnedMemoryAllocator() {
   C10_LOG_API_USAGE_ONCE("aten.init.npu");
-  c10_npu::NpuSysCtrl::SysStatus status =
-      c10_npu::NpuSysCtrl::GetInstance().Initialize();
-  if (status != c10_npu::NpuSysCtrl::SysStatus::INIT_SUCC) {
+  if (!c10_npu::NpuSysCtrl::IsInitializeSuccess()) {
     ASCEND_LOGE("Npu init fail.");
   }
   return getTHNPUCachingHostAllocator();

--- a/backend/npu/impl/core/DeviceUtils.h
+++ b/backend/npu/impl/core/DeviceUtils.h
@@ -47,11 +47,15 @@ inline c10::DeviceType get_npu_device_type() {
   return c10::DeviceType::PrivateUse1;
 }
 
+inline bool is_initialize_success(int device_id) {
+  c10_npu::NpuSysCtrl::SysStatus status =
+      c10_npu::NpuSysCtrl::GetInstance().Initialize(device_id);
+  return status == c10_npu::NpuSysCtrl::SysStatus::INIT_SUCC;
+}
+
 inline void maybe_initialize_npu(const at::TensorOptions& options) {
   if (torch_npu::utils::is_npu(options)) {
-    c10_npu::NpuSysCtrl::SysStatus status =
-        c10_npu::NpuSysCtrl::GetInstance().Initialize(options.device().index());
-    if (status != c10_npu::NpuSysCtrl::SysStatus::INIT_SUCC) {
+    if (!torch_npu::utils::is_initialize_success(options.device().index())) {
       TORCH_CHECK(
           false,
           "npu device ",
@@ -67,9 +71,7 @@ inline void maybe_initialize_npu(const at::TensorOptions& options) {
 
 inline void maybe_initialize_npu(const at::Device& device) {
   if (torch_npu::utils::is_npu(device)) {
-    c10_npu::NpuSysCtrl::SysStatus status =
-        c10_npu::NpuSysCtrl::GetInstance().Initialize(device.index());
-    if (status != c10_npu::NpuSysCtrl::SysStatus::INIT_SUCC) {
+    if (!torch_npu::utils::is_initialize_success(device.index())) {
       TORCH_CHECK(
           false,
           "npu device ",

--- a/backend/npu/impl/core/DeviceUtils.h
+++ b/backend/npu/impl/core/DeviceUtils.h
@@ -47,15 +47,9 @@ inline c10::DeviceType get_npu_device_type() {
   return c10::DeviceType::PrivateUse1;
 }
 
-inline bool is_initialize_success(int device_id) {
-  c10_npu::NpuSysCtrl::SysStatus status =
-      c10_npu::NpuSysCtrl::GetInstance().Initialize(device_id);
-  return status == c10_npu::NpuSysCtrl::SysStatus::INIT_SUCC;
-}
-
 inline void maybe_initialize_npu(const at::TensorOptions& options) {
   if (torch_npu::utils::is_npu(options)) {
-    if (!torch_npu::utils::is_initialize_success(options.device().index())) {
+    if (!c10_npu::NpuSysCtrl::IsInitializeSuccess(options.device().index())) {
       TORCH_CHECK(
           false,
           "npu device ",
@@ -71,7 +65,7 @@ inline void maybe_initialize_npu(const at::TensorOptions& options) {
 
 inline void maybe_initialize_npu(const at::Device& device) {
   if (torch_npu::utils::is_npu(device)) {
-    if (!torch_npu::utils::is_initialize_success(device.index())) {
+    if (!c10_npu::NpuSysCtrl::IsInitializeSuccess(device.index())) {
       TORCH_CHECK(
           false,
           "npu device ",

--- a/backend/npu/impl/core/NPUGuard.h
+++ b/backend/npu/impl/core/NPUGuard.h
@@ -3,8 +3,9 @@
 #include <c10/core/DeviceType.h>
 #include <c10/core/impl/InlineDeviceGuard.h>
 #include <c10/core/impl/InlineStreamGuard.h>
-#include "backend/npu/impl/core/NPUMacros.h"
+#include "backend/core/PrivateUse1Guard.h"
 #include "backend/npu/NPUGuardImpl.h"
+#include "backend/npu/impl/core/NPUMacros.h"
 
 #include <cstddef>
 
@@ -18,16 +19,9 @@ namespace c10_npu {
 /// more efficient than DeviceGuard (it compiles to straight line
 /// NPUSetDevice/NPUGetDevice calls); however, it can only be used
 /// from code that links against NPU directly.
-struct NPUGuard {
-  /// No default constructor; see Note [Omitted default constructor from RAII]
-  explicit NPUGuard() = delete;
-
-  /// Set the current NPU device to the passed device index.
-  explicit NPUGuard(c10::DeviceIndex device_index) : guard_(device_index) {}
-
-  /// Sets the current NPU device to the passed device.  Errors if the passed
-  /// device is not a NPU device.
-  explicit NPUGuard(c10::Device device) : guard_(device) {}
+struct NPUGuard : public c10_backend::PrivateUse1Guard<impl::NPUGuardImpl> {
+  using PrivateUse1Guard = c10_backend::PrivateUse1Guard<impl::NPUGuardImpl>;
+  using PrivateUse1Guard::PrivateUse1Guard;
 
   // Copy is not allowed
   NPUGuard(const NPUGuard&) = delete;
@@ -36,55 +30,15 @@ struct NPUGuard {
   // Move is not allowed (there is no uninitialized state)
   NPUGuard(NPUGuard&& other) = delete;
   NPUGuard& operator=(NPUGuard&& other) = delete;
-
-  /// Sets the NPU device to the given device.  Errors if the given device
-  /// is not a NPU device.
-  void set_device(c10::Device device) {
-    guard_.set_device(device);
-  }
-
-  /// Sets the NPU device to the given device.  Errors if the given device
-  /// is not a NPU device.  (This method is provided for uniformity with
-  /// DeviceGuard).
-  void reset_device(c10::Device device) {
-    guard_.reset_device(device);
-  }
-
-  /// Sets the NPU device to the given device index.
-  void set_index(c10::DeviceIndex device_index) {
-    guard_.set_index(device_index);
-  }
-
-  /// Returns the device that was set upon construction of the guard
-  c10::Device original_device() const {
-    return guard_.original_device();
-  }
-
-  /// Returns the last device that was set via `set_device`, if any, otherwise
-  /// the device passed during construction.
-  c10::Device current_device() const {
-    return guard_.current_device();
-  }
-
- private:
-  /// The guard for the current device.
-  c10::impl::InlineDeviceGuard<c10_npu::impl::NPUGuardImpl> guard_;
 };
 
 /// A variant of OptionalDeviceGuard that is specialized for NPU.  See
 /// NPUGuard for when you can use this.
-struct OptionalNPUGuard {
-  /// Create an uninitialized OptionalNPUGuard.
-  explicit OptionalNPUGuard() : guard_() {}
-
-  /// Set the current NPU device to the passed Device, if it is not nullopt.
-  explicit OptionalNPUGuard(c10::optional<c10::Device> device_opt)
-      : guard_(device_opt) {}
-
-  /// Set the current NPU device to the passed device index, if it is not
-  /// nullopt
-  explicit OptionalNPUGuard(c10::optional<c10::DeviceIndex> device_index_opt)
-      : guard_(device_index_opt) {}
+struct OptionalNPUGuard
+    : public c10_backend::OptionalPrivateUse1Guard<impl::NPUGuardImpl> {
+  using OptionalPrivateUse1Guard =
+      c10_backend::OptionalPrivateUse1Guard<impl::NPUGuardImpl>;
+  using OptionalPrivateUse1Guard::OptionalPrivateUse1Guard;
 
   // Copy is not allowed
   OptionalNPUGuard(const OptionalNPUGuard&) = delete;
@@ -95,48 +49,6 @@ struct OptionalNPUGuard {
 
   // See Note [Move assignment for RAII guards is tricky]
   OptionalNPUGuard& operator=(OptionalNPUGuard&& other) = delete;
-
-  /// Sets the NPU device to the given device, initializing the guard if it
-  /// is not already initialized.  Errors if the given device is not a NPU
-  /// device.
-  void set_device(c10::Device device) {
-    guard_.set_device(device);
-  }
-
-  /// Sets the NPU device to the given device, initializing the guard if it is
-  /// not already initialized.  Errors if the given device is not a NPU device.
-  /// (This method is provided for uniformity with OptionalDeviceGuard).
-  void reset_device(c10::Device device) {
-    guard_.reset_device(device);
-  }
-
-  /// Sets the NPU device to the given device index, initializing the guard if
-  /// it is not already initialized.
-  void set_index(c10::DeviceIndex device_index) {
-    guard_.set_index(device_index);
-  }
-
-  /// Returns the device that was set immediately prior to initialization of the
-  /// guard, or nullopt if the guard is uninitialized.
-  c10::optional<c10::Device> original_device() const {
-    return guard_.original_device();
-  }
-
-  /// Returns the most recent device that was set using this device guard,
-  /// either from construction, or via set_device, if the guard is initialized,
-  /// or nullopt if the guard is uninitialized.
-  c10::optional<c10::Device> current_device() const {
-    return guard_.current_device();
-  }
-
-  /// Restore the original NPU device, resetting this guard to uninitialized
-  /// state.
-  void reset() {
-    guard_.reset();
-  }
-
- private:
-  c10::impl::InlineOptionalDeviceGuard<impl::NPUGuardImpl> guard_;
 };
 
 /// A variant of StreamGuard that is specialized for NPU.  See NPUGuard

--- a/backend/npu/impl/core/sys_ctrl/npu_sys_ctrl.cpp
+++ b/backend/npu/impl/core/sys_ctrl/npu_sys_ctrl.cpp
@@ -234,6 +234,16 @@ void initCachingAllocator() {
   ASCEND_LOGD("Npu caching allocator initialize successfully");
 }
 
+inline bool NpuSysCtrl::IsInitializeSuccess(int device_id) {
+  SysStatus status = GetInstance().Initialize(device_id);
+  return status == SysStatus::INIT_SUCC;
+}
+
+inline bool NpuSysCtrl::IsFinalizeSuccess() {
+  SysStatus status = GetInstance().Finalize();
+  return status == SysStatus::FINALIZE_SUCC;
+}
+
 // Environment Initialize, return Status: SUCCESS, FAILED
 NpuSysCtrl::SysStatus NpuSysCtrl::Initialize(int device_id) {
   if (init_flag_) {

--- a/backend/npu/impl/core/sys_ctrl/npu_sys_ctrl.h
+++ b/backend/npu/impl/core/sys_ctrl/npu_sys_ctrl.h
@@ -37,6 +37,10 @@ class NpuSysCtrl {
   // Get NpuSysCtrl singleton instance
   C10_NPU_API static NpuSysCtrl& GetInstance();
 
+  C10_NPU_API static inline bool IsInitializeSuccess(int device_id = -1);
+
+  C10_NPU_API static inline bool IsFinalizeSuccess();
+
   // Environment Initialize, return SysStatus
   SysStatus Initialize(int device_id = -1);
 

--- a/torch_npu/csrc/Module.cpp
+++ b/torch_npu/csrc/Module.cpp
@@ -63,9 +63,7 @@ PyObject* THPModule_npu_shutdown(PyObject* /* unused */) {
   }
 
   ASCEND_LOGI("NPU shutdown NpuSysCtrl Finalize.");
-  c10_npu::NpuSysCtrl::SysStatus status =
-      c10_npu::NpuSysCtrl::GetInstance().Finalize();
-  if (status != c10_npu::NpuSysCtrl::SysStatus::FINALIZE_SUCC) {
+  if (!c10_npu::NpuSysCtrl::IsFinalizeSuccess()) {
     ASCEND_LOGE("NPU shutdown failed.");
   } else {
     ASCEND_LOGI("NPU shutdown success.");

--- a/torch_npu/csrc/npu/Module.cpp
+++ b/torch_npu/csrc/npu/Module.cpp
@@ -218,7 +218,7 @@ static PyObject* THNPModule_initExtension(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
     if (!c10_npu::NpuSysCtrl::IsInitializeSuccess()) {
-        throw python_error();
+      throw python_error();
     }
   }
   auto m = THPObjectPtr(PyImport_ImportModule("torch.npu"));
@@ -264,7 +264,7 @@ PyObject* THNPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
   int device = THPUtils_unpackInt(arg);
   {
     pybind11::gil_scoped_release no_gil;
-      if (!c10_npu::NpuSysCtrl::IsInitializeSuccess(device)) {
+    if (!c10_npu::NpuSysCtrl::IsInitializeSuccess(device)) {
       ASCEND_LOGE("Npu init fail.");
     }
   }

--- a/torch_npu/csrc/npu/Module.cpp
+++ b/torch_npu/csrc/npu/Module.cpp
@@ -263,12 +263,10 @@ void THNPModule_setDevice(int device) {
 
 PyObject* THNPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
   HANDLE_TH_ERRORS
-  int device = THPUtils_unpackLong(arg);
+  int device = THPUtils_unpackInt(arg);
   {
     pybind11::gil_scoped_release no_gil;
-    c10_npu::NpuSysCtrl::SysStatus status =
-        c10_npu::NpuSysCtrl::GetInstance().Initialize(device);
-    if (status != c10_npu::NpuSysCtrl::SysStatus::INIT_SUCC) {
+    if (!torch_npu::utils::is_initialize_success(device)) {
       ASCEND_LOGE("Npu init fail.");
     }
   }
@@ -290,19 +288,19 @@ PyObject* THNPModule_getDevice_wrap(PyObject* self, PyObject* noargs) {
   int device;
   torch_npu::utils::npu_lazy_init();
   NPU_CHECK_ERROR(c10_npu::GetDevice(&device));
-  return PyLong_FromLong(device);
+  return THPUtils_packInt32(device);
   END_HANDLE_TH_ERRORS
 }
 
 PyObject* THNPModule_getDeviceCount_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  return PyLong_FromLong(c10_npu::device_count());
+  return THPUtils_packInt32(c10_npu::device_count());
   END_HANDLE_TH_ERRORS
 }
 
 PyObject* THNPModule_getLocalDevice_wrap(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS
-  return PyLong_FromLong(c10_npu::GetLocalDevice());
+  return THPUtils_packInt32(c10_npu::GetLocalDevice());
   END_HANDLE_TH_ERRORS
 }
 
@@ -316,8 +314,8 @@ PyObject* THNPModule_npuCanDeviceAccessPeer_wrap(
     throw torch::TypeError(
         "Pybind failed to parse parameters." + PTA_ERROR(ErrCode::TYPE));
   }
-  int32_t device_id = THPUtils_unpackInt(value_1);
-  int32_t peer_device_id = THPUtils_unpackInt(value_2);
+  c10::DeviceIndex device_id = THPUtils_unpackDeviceIndex(value_1);
+  c10::DeviceIndex peer_device_id = THPUtils_unpackDeviceIndex(value_2);
   auto can_access_peer =
       c10_npu::acl::can_device_access_peer(device_id, peer_device_id);
   return PyBool_FromLong(can_access_peer);
@@ -332,34 +330,13 @@ PyObject* THNPModule_getDeviceUtilizationRate_wrap(
       THPUtils_checkLong(device_index),
       "invalid argument to getDeviceUtilizationRate",
       PTA_ERROR(ErrCode::VALUE));
-  int32_t device = static_cast<int32_t>(THPUtils_unpackUInt32(device_index));
-  aclrtUtilizationInfo util_info;
-  util_info.cubeUtilization = 0;
-  util_info.vectorUtilization = 0;
-  util_info.utilizationExtend = nullptr;
-  NPU_CHECK_ERROR(
-      c10_npu::acl::AclrtGetDeviceUtilizationRate(device, &util_info));
-  int32_t cube = util_info.cubeUtilization;
-  int32_t vector = util_info.vectorUtilization;
-  int32_t util_rate = 0;
-  // 如果vector和cube谁支持,就返回谁的使用率，如果都支持计算(vector*1+cube*1)/2
-  if (cube == DEVICE_UTILIZATION_NOT_SUPPORT &&
-      vector != DEVICE_UTILIZATION_NOT_SUPPORT) {
-    util_rate = vector;
-  } else if (
-      cube != DEVICE_UTILIZATION_NOT_SUPPORT &&
-      vector == DEVICE_UTILIZATION_NOT_SUPPORT) {
-    util_rate = cube;
-  } else if (
-      cube != DEVICE_UTILIZATION_NOT_SUPPORT &&
-      vector != DEVICE_UTILIZATION_NOT_SUPPORT) {
-    util_rate = (cube + vector) / 2;
-  }
+  int32_t device = THPUtils_unpackInt(device_index);
+  int32_t util_rate = c10_npu::getDeviceUtilizationRate(device);
   TORCH_CHECK(
       util_rate <= 100 && util_rate >= 0,
       "invalid result to util_rate",
       PTA_ERROR(ErrCode::VALUE));
-  return PyLong_FromLong(util_rate);
+  return THPUtils_packInt32(util_rate);
   END_HANDLE_TH_ERRORS
 }
 

--- a/torch_npu/csrc/npu/Module.cpp
+++ b/torch_npu/csrc/npu/Module.cpp
@@ -217,10 +217,8 @@ void RegisterNpuPluggableAllocator(PyObject* module) {
 static PyObject* THNPModule_initExtension(PyObject* self, PyObject* noargs) {
   HANDLE_TH_ERRORS {
     pybind11::gil_scoped_release no_gil;
-    c10_npu::NpuSysCtrl::SysStatus status =
-        c10_npu::NpuSysCtrl::GetInstance().Initialize();
-    if (status != c10_npu::NpuSysCtrl::SysStatus::INIT_SUCC) {
-      throw python_error();
+    if (!c10_npu::NpuSysCtrl::IsInitializeSuccess()) {
+        throw python_error();
     }
   }
   auto m = THPObjectPtr(PyImport_ImportModule("torch.npu"));
@@ -266,7 +264,7 @@ PyObject* THNPModule_setDevice_wrap(PyObject* self, PyObject* arg) {
   int device = THPUtils_unpackInt(arg);
   {
     pybind11::gil_scoped_release no_gil;
-    if (!torch_npu::utils::is_initialize_success(device)) {
+      if (!c10_npu::NpuSysCtrl::IsInitializeSuccess(device)) {
       ASCEND_LOGE("Npu init fail.");
     }
   }

--- a/torch_npu/csrc/npu/Module.cpp
+++ b/torch_npu/csrc/npu/Module.cpp
@@ -329,7 +329,7 @@ PyObject* THNPModule_getDeviceUtilizationRate_wrap(
       "invalid argument to getDeviceUtilizationRate",
       PTA_ERROR(ErrCode::VALUE));
   int32_t device = THPUtils_unpackInt(device_index);
-  int32_t util_rate = c10_npu::getDeviceUtilizationRate(device);
+  int32_t util_rate = c10_npu::GetDeviceUtilizationRate(device);
   TORCH_CHECK(
       util_rate <= 100 && util_rate >= 0,
       "invalid result to util_rate",


### PR DESCRIPTION
- 抽取 Device 相关 binding 代码。将与 binding 逻辑无关且与 NPU 逻辑相关的内容提取出来
- 重构 DeviceGuard 相关。抽取 `PrivateUse1GuardImpl` 和 `PrivateUse1Guard`，作为设备 Guard 的父类
